### PR TITLE
🩹 fixed bug in ServerManager.cs where if you stop and start a server …

### DIFF
--- a/SpigotWrapper/Config/Enums.cs
+++ b/SpigotWrapper/Config/Enums.cs
@@ -16,5 +16,6 @@ namespace SpigotWrapper.Config
         JarKindAndVersionMustBeUniqueTogether = 2,
         ServerNameMustBeUnique = 3,
         JarFileDoesNotExist = 4,
+        PluginDoesNotExist = 5,
     }
 }

--- a/SpigotWrapper/Config/Mapping/DataMappingProfile.cs
+++ b/SpigotWrapper/Config/Mapping/DataMappingProfile.cs
@@ -14,11 +14,17 @@ namespace SpigotWrapper.Config.Mapping
             CreateMap<Plugin, PluginDto>();
             CreateMap<PluginDto, Plugin>();
 
+            CreateMap<Plugin, SpigotWrapperLib.Plugin.Plugin>();
+            CreateMap<SpigotWrapperLib.Plugin.Plugin, Plugin>();
+
             CreateMap<SpigotWrapperSetting, SpigotWrapperSettingDto>();
             CreateMap<SpigotWrapperSettingDto, SpigotWrapperSetting>();
 
             CreateMap<Server, ServerDto>();
             CreateMap<ServerDto, Server>();
+
+            CreateMap<PluginServer, PluginServerDto>();
+            CreateMap<PluginServerDto, PluginServer>();
 
             CreateMap<Server, Wrapper>();
             CreateMap<Wrapper, Server>();

--- a/SpigotWrapper/Config/TextPlainInputFormatter.cs
+++ b/SpigotWrapper/Config/TextPlainInputFormatter.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Formatters;
 
-namespace SpigotWrapper;
+namespace SpigotWrapper.Config;
 
 public class TextPlainInputFormatter : InputFormatter
 {
@@ -27,6 +26,6 @@ public class TextPlainInputFormatter : InputFormatter
   public override bool CanRead(InputFormatterContext context)
   {
       var contentType = context.HttpContext.Request.ContentType;
-      return contentType.StartsWith(ContentType);
+      return contentType != null && contentType.StartsWith(ContentType);
   }
 }

--- a/SpigotWrapper/Controllers/JarController.cs
+++ b/SpigotWrapper/Controllers/JarController.cs
@@ -83,10 +83,10 @@ namespace SpigotWrapper.Controllers
         {
             var jar = await _jarService.DownloadJar(jarDownloadRequest.DownloadUrl, jarDownloadRequest.FileName,
                 jarDownloadRequest.JarKind, jarDownloadRequest.MinecraftVersion);
-            if (typeof(Error) == jar.GetType() && jar == Error.JarAlreadyDownloaded)
-                return BadRequest(jar);
             if (jar == null)
                 return BadRequest();
+            if (typeof(Error) == jar.GetType() && jar == Error.JarAlreadyDownloaded)
+                return BadRequest(jar);
             return jar;
         }
 
@@ -96,10 +96,10 @@ namespace SpigotWrapper.Controllers
         public async Task<ActionResult<dynamic>> DownloadLatest()
         {
             var jar = await _jarService.DownloadLatest();
-            if (typeof(Error) == jar.GetType() && jar == Error.JarAlreadyDownloaded)
-                return BadRequest(jar);
             if (jar == null)
                 return BadRequest();
+            if (typeof(Error) == jar.GetType() && jar == Error.JarAlreadyDownloaded)
+                return BadRequest(jar);
             return jar;
         }
     }

--- a/SpigotWrapper/Services/Plugins/PluginService.cs
+++ b/SpigotWrapper/Services/Plugins/PluginService.cs
@@ -57,8 +57,10 @@ namespace SpigotWrapper.Services.Plugins
 
         public async Task Remove(Guid id)
         {
+            var plugin = await _pluginRepository.Get(id);
             await _pluginRepository.Remove(id);
-            _logger.Info($"Removed {id})");
+            File.Delete(Path.Combine(PluginPath, plugin.FileName));
+            _logger.Info($"Removed {plugin.Name}");
         }
     }
 }

--- a/SpigotWrapper/Services/Servers/ServerService.cs
+++ b/SpigotWrapper/Services/Servers/ServerService.cs
@@ -62,7 +62,7 @@ namespace SpigotWrapper.Services.Servers
                 var javaExecutable = spigotWrapperRepository!.Get("JavaExecutable").GetAwaiter().GetResult().Value;
                 foreach (var server in servers!)
                 {
-                    EnrichWithEnabledPlugins(server, pluginRepository, pluginServerRepository).GetAwaiter();
+                    EnrichWithEnabledPlugins(server, pluginRepository, pluginServerRepository).GetAwaiter().GetResult();
                     var libServer = mapper!.Map<Server, Wrapper>(server);
                     libServer.ServerPath = Path.Combine(ServerPath, libServer.Id.ToString());
                     libServer.JavaExecutable = javaExecutable;
@@ -184,7 +184,7 @@ namespace SpigotWrapper.Services.Servers
                 var plugins = new List<Plugin>();
                 foreach (var pluginServer in pluginsServer)
                     plugins.Add(await pluginRepository.Get(pluginServer.PluginId));
-                server.EnabledPlugins = plugins.ToArray();
+                server.EnabledPlugins = plugins.Count > 0 ? plugins.ToArray() : Array.Empty<Plugin>();
             }
         }
 

--- a/SpigotWrapperLib/API/Config.cs
+++ b/SpigotWrapperLib/API/Config.cs
@@ -27,7 +27,7 @@ namespace SpigotWrapperLib.API
         public string GetConfig(string name)
         {
             var fileName = Path.Combine(_configPath, name) + ".json";
-            return !File.Exists(fileName) ? null : File.ReadAllText(fileName);
+            return !File.Exists(fileName) ? "" : File.ReadAllText(fileName);
         }
         
         public void SaveConfig<T>(T config) where T : IConfig

--- a/SpigotWrapperLib/Log/Backup.cs
+++ b/SpigotWrapperLib/Log/Backup.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace SpigotWrapperLib.Log
 {
-    public class Backup
+    public static class Backup
     {
         private static bool _backedUpLogs;
         

--- a/SpigotWrapperLib/Log/Logger.cs
+++ b/SpigotWrapperLib/Log/Logger.cs
@@ -15,11 +15,9 @@ namespace SpigotWrapperLib.Log
         public static void Error(object className, object line) => Log($"[{DateTime.Now}] [{className}/ERROR]: {line}");
         public static void Fatal(object className, object line) => Log($"[{DateTime.Now}] [{className}/FATAL]: {line}");
 
-        private string _className;
+        private readonly string _className;
         public Logger(string className)
-        {
-            _className = className;
-        }
+            => _className = className;
 
         public void Debug(object line) => Debug(_className, line);
         public void Info(object line) => Info(_className, line);

--- a/SpigotWrapperLib/Plugin/ISpigotWrapperPlugin.cs
+++ b/SpigotWrapperLib/Plugin/ISpigotWrapperPlugin.cs
@@ -3,5 +3,6 @@ namespace SpigotWrapperLib.Plugin
     public interface ISpigotWrapperPlugin
     {
         string Name { get; }
+        void UnloadPlugin();
     }
 }

--- a/SpigotWrapperLib/Server/MinecraftConnector.cs
+++ b/SpigotWrapperLib/Server/MinecraftConnector.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using SpigotWrapperLib.Events;
+using SpigotWrapperLib.Log;
 
 namespace SpigotWrapperLib.Server
 {
@@ -52,6 +53,10 @@ namespace SpigotWrapperLib.Server
                 }
                 else if (message.Contains("Teleported"))
                 {
+                    //TODO: handle following Minecraft server output: Teleported <playername> to <playername>
+                    if (!message.Contains(":"))
+                        return;
+                    
                     var toSplit = !message.StartsWith("Teleported")
                         ? message[(message.IndexOf(":", StringComparison.Ordinal) + 2)..^1]
                         : message;
@@ -68,7 +73,7 @@ namespace SpigotWrapperLib.Server
             }
             catch (ArgumentOutOfRangeException exception)
             {
-                Console.WriteLine(exception);
+                Logger.Error("MinecraftConnector", exception);
             }
         }
 
@@ -78,14 +83,14 @@ namespace SpigotWrapperLib.Server
         private void TriggerEvent<T>(EventHandler<T> eventHandler, T args) where T : EventArgs
             => eventHandler?.Invoke(this, args);
 
-        public static event EventHandler<PlayerJoinedEventArgs> PlayerJoin;
-        public static event EventHandler<PlayerLeftEventArgs> PlayerLeft;
-        public static event EventHandler<PlayerChatEventArgs> PlayerChatReceived;
-        public static event EventHandler<PlayerPositionEventArgs> PlayerPositionReceived;
+        public event EventHandler<PlayerJoinedEventArgs> PlayerJoin;
+        public event EventHandler<PlayerLeftEventArgs> PlayerLeft;
+        public event EventHandler<PlayerChatEventArgs> PlayerChatReceived;
+        public event EventHandler<PlayerPositionEventArgs> PlayerPositionReceived;
 
-        public static event EventHandler<ServerEventArgs> ServerStart;
-        public static event EventHandler<ServerEventArgs> ServerStarted;
-        public static event EventHandler<ServerEventArgs> ServerStop;
-        public static event EventHandler<ServerEventArgs> ServerStopped;
+        public event EventHandler<ServerEventArgs> ServerStart;
+        public event EventHandler<ServerEventArgs> ServerStarted;
+        public event EventHandler<ServerEventArgs> ServerStop;
+        public event EventHandler<ServerEventArgs> ServerStopped;
     }
 }

--- a/SpigotWrapperLib/Server/ServerManager.cs
+++ b/SpigotWrapperLib/Server/ServerManager.cs
@@ -75,9 +75,7 @@ namespace SpigotWrapperLib.Server
         public void WaitForStop(Guid id)
         {
             while (IsRunning(id))
-            {
                 Thread.Sleep(10);
-            }
         }
 
         public List<Wrapper> GetAllInfo(int count = -1)
@@ -102,8 +100,12 @@ namespace SpigotWrapperLib.Server
             => _wrappers.FirstOrDefault(server => server.Id == id)?.ServerProperties;
         public string LatestLog(Guid id)
             => _wrappers.FirstOrDefault(server => server.Id == id)?.LatestLog;
+
         public bool IsRunning(Guid id)
-            => _wrappers.FirstOrDefault(server => server.Id == id)?.IsRunning ?? false;
+        {
+            try { return _wrappers.FirstOrDefault(server => server.Id == id)?.IsRunning ?? false; }
+            catch { return false; }
+        }
         public void WaitForAllToStop()
             => _wrappers.ForEach(server => WaitForStop(server.Id));
     }


### PR DESCRIPTION
…it didn't try/catch a IsRunning check on that server (if the timing is right you get an error saying the _server process is not pointing to anything)

🐛 fixed PluginManager (added mapping profiles, ability to UnloadPlugins (on server stop), changed from AppDomain to AssemblyLoadContext (to be able to unload plugins)) 🐛 fixed bug where MinecraftConnector.cs events were static, so all servers wouldn't fire individually but on all servers. also instantiated the MinecraftConnector inside Wrapper.cs 🐛 fixed a bug where if you would Remove a plugin, it would remove it from the database but not from the File system ♻️ refactored some code, added some readonly keywords and cleaned up some code with lambda expressions